### PR TITLE
make the repo compliant with our open source policies

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+**Describe what happened:**
+
+
+**Describe what you expected:**
+
+
+**Steps to reproduce the issue:**
+
+
+**Additional environment details (Operating System, Cloud provider, etc):**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What does this PR do?
+
+A brief description of the change being made with this pull request.
+
+### Motivation
+
+What inspired you to submit this pull request?
+
+### Additional Notes
+
+Anything else we should know when reviewing?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to the Datadog FluentD Plugin
+
+:tada: First, thanks for contributing! :tada:
+
+## Submitting Issues
+
+- First take a look at the [Troubleshooting section](https://help.datadoghq.com/hc/en-us/categories/115001116846-Log-Management-Beta-) of our [Knowledge Base](https://help.datadoghq.com/hc/en-us).
+- If you can't find anything useful, please contact our Solutions Team for assistance.
+- Finally, you can open a Gitbub issue
+
+## Pull Requests
+
+Thanks for helping this plugin grow! In order to ease/speed up our review, here are some items you can check/iprove when submitting your PR:
+
+- [ ] have a [proper commit history](#commits) (we advise you to rebase if needed).
+- [ ] write tests for the code you wrote.
+- [ ] preferably make sure that all tests pass locally.
+- [ ] summarize your PR with a descriptive title and a message describing your changes, cross-referencing any related bugs/PRs.
+
+## Commits
+
+- Pleaes keep each commit's changes small and focused--many changes in the same commit makes them harder to review.
+- Please also combine each code-change within one commit rather than many commits. Rebase liberally. 
+- Please make all commit messages clear and communicative.
+
+Following these rules keeps history cleaner, makes it easier to revert things, and it makes developers happier too.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-datadog.gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Datadog, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,0 +1,5 @@
+Component,Origin,License
+plugin,github.com/brianmario/yajl-ruby,MIT
+plugin,github.com/bundler/bundler,MIT
+plugin,github.com/ruby/openssl,BSD-2-Clause
+plugin,github.com/ruby/rake,MIT

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Datadog fluentd-plugin
+Copyright 2017 Datadog, Inc.
+
+This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
 require "bundler/gem_tasks"

--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -1,3 +1,8 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -1,3 +1,8 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
 require 'socket'
 require 'openssl'
 require 'yajl'

--- a/test/fluentd-test.conf
+++ b/test/fluentd-test.conf
@@ -1,3 +1,8 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
 <source>
   @type forward
   port 24224


### PR DESCRIPTION
Completes the checklist available [here](https://github.com/Datadog/devops/wiki/Datadog-Open-Source-Policy#releasing-a-new-open-source-repository). Largely used other recent open source Datadog repos for reference. 