### PR TITLE
Fix retry count

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -134,7 +134,6 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
         # Check the connectivity and write messages
         log.info "New attempt to Datadog attempt=#{retries}" if retries > 0
 
-        retries = retries + 1
         data.each do |event|
           log.trace "Datadog plugin: about to send event=#{event}"
           client.write(event)


### PR DESCRIPTION
Retries was being incremented in two places... once in the body of the
begin block and once in the rescue. This would lead to the retry count
increasing by 2 on every attempt and leading to a very confusing attempt
count of 2 on the first failure. It's now only incremented in the rescue
block after logging the failure message.