### PR TITLE
default to using ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 | **use_json**| Event format, if true, the event is sent in json format. Othwerwise, in plain text. | true      |
 | **include_tag_key**| Automatically include tags in the record. | false      |
 | **tag_key**| Name of the tag attribute, if they are included. | "tag"      |
-| **use_ssl** | If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise. | false |
+| **use_ssl** | If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise. | true |
 |**max_retries**| The number of retries before the output plugin stops. Set to -1 for unlimited retries | -1 |

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -19,7 +19,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
 
   # Connection settings
   config_param :host,           :string,  :default => 'intake.logs.datadoghq.com'
-  config_param :use_ssl,        :bool,    :default => false
+  config_param :use_ssl,        :bool,    :default => true
   config_param :port,           :integer, :default => 10514
   config_param :ssl_port,       :integer, :default => 10516
   config_param :max_retries,    :integer, :default => -1


### PR DESCRIPTION
### What does this PR do?

This PR defaults the gem into a _sane_ default of `use_ssl => true`

### Motivation

In 2018 it is absolutely _fudging_ irresponsible to default to plain text network connectivity.

### Additional Notes

This should be merged ASAP.