### PR TITLE
Set dd_sourcecategory, dd_source and dd_tags as optional parameters

### DIFF
--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -9,7 +9,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-datadog"
-  spec.version       = "0.10.1"
+  spec.version       = "0.10.2"
   spec.authors       = ["Datadog Solutions Team"]
   spec.email         = ["support@datadoghq.com"]
   spec.summary       = "Datadog output plugin for Fluent event collector"

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -16,9 +16,9 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
   config_param :use_json,           :bool,    :default => true
   config_param :include_tag_key,    :bool,    :default => false
   config_param :tag_key,            :string,  :default => 'tag'
-  config_param :dd_sourcecategory,  :string
-  config_param :dd_source,          :string
-  config_param :dd_tags,            :string
+  config_param :dd_sourcecategory,  :string,  :default => nil
+  config_param :dd_source,          :string,  :default => nil
+  config_param :dd_tags,            :string,  :default => nil
 
   # Connection settings
   config_param :host,           :string,  :default => 'intake.logs.datadoghq.com'


### PR DESCRIPTION
### What does this PR do?

Added default values for `dd_sourcecategory`, `dd_source` and `dd_tags`.

### Motivation

All those parameters should be optional.

### Additional Notes

This should solve https://github.com/DataDog/fluent-plugin-datadog/issues/9