### PR TITLE
Actually use tcp_ping_rate as the ping rate

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -84,7 +84,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
           messages = Array.new
           messages.push("fp\n")
           send_to_datadog(messages)
-          sleep(15)
+          sleep(@tcp_ping_rate)
         end
       end
     end


### PR DESCRIPTION
### Motivation

Previously, the ping rate was hardcoded to once every 15 seconds, regardless of the configuration. Allowing the rate to actually be configured may help help mitigate #5. At the very least, it's truth in advertising :)

### Additional Notes

I don't know if there's an undocumented internal reason for the ping rate to be hard coded. If there is, then the configuration point should probably just be deprecated and eventually removed to reduce confusion.