### PR TITLE
Migrate to use v1 API

### DIFF
--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "yajl-ruby", "~> 1.2"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
 end


### PR DESCRIPTION
Fixes #19

### What does this PR do?

Use the brand new Fluentd v1 API.

### Motivation

I want to use Fluentd v1 API in this plugin.

### Additional Notes

Fluentd v1 API does not have backward compatibility.
If you merge this patch, users must upgrade their Fluentd. (From v0.12
to 0.14/v1)

Fluentd v1 has plugin helper layer which provides some encapsulated
utility methods.

In Fluentd v2 (future release), v0.12 API, which is traditional Fluentd API, not be supported.