### PR TITLE
Update read me to reflect the `ssl_port` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 | **include_tag_key** | Automatically include tags in the record. | false |
 | **tag_key** | Name of the tag attribute, if they are included. | "tag" |
 | **use_ssl** | If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise. | true |
+| **ssl_port** | Port used to send logs over a SSL encripted connection to Datadog (use 443 for the EU region) | 10516 |
 | **max_retries** | The number of retries before the output plugin stops. Set to -1 for unlimited retries | -1 |
 | **dd_source** | This tells Datadog what integration it is | nil |
 | **dd_sourcecategory** | Multiple value attribute. Can be used to refine the source attribtue | nil |
 | **dd_tags** | Custom tags with the following format "key1:value1, key2:value2" | nil |
-| **port** | Proxy port when logs are not directly forwarded to Datadog | 10516 |
+| **port** | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | 10514 |
 | **host** | Proxy endpoint when logs are not directly forwarded to Datadog | intake.logs.datadoghq.com |
 
 ### Docker and Kubernetes tags


### PR DESCRIPTION
### What does this PR do?

Update the list of parameters with `ssl_port` to reflect the fact that it should be used when using a SSL connection.

### Motivation

The documentation was misleading and one could have believed that `port` was enough to configure this.

### Additional Notes

Anything else we should know when reviewing?