### PR TITLE
Propagate timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 | **use_json** | Event format, if true, the event is sent in json format. Othwerwise, in plain text. | true |
 | **include_tag_key** | Automatically include tags in the record. | false |
 | **tag_key** | Name of the tag attribute, if they are included. | "tag" |
+| **timestamp_key** | Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added. | "@timestamp" |
 | **use_ssl** | If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise. | true |
 | **ssl_port** | Port used to send logs over a SSL encripted connection to Datadog (use 443 for the EU region) | 10516 |
 | **max_retries** | The number of retries before the output plugin stops. Set to -1 for unlimited retries | -1 |

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -16,6 +16,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
   config_param :use_json,           :bool,    :default => true
   config_param :include_tag_key,    :bool,    :default => false
   config_param :tag_key,            :string,  :default => 'tag'
+  config_param :timestamp_key       :string,  :default => '@timestamp'
   config_param :dd_sourcecategory,  :string,  :default => nil
   config_param :dd_source,          :string,  :default => nil
   config_param :dd_tags,            :string,  :default => nil
@@ -87,7 +88,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
 
   # This method is called when an event reaches Fluentd.
   def format(tag, time, record)
-    return [tag, record].to_msgpack
+    return [tag, time, record].to_msgpack
   end
 
   # NOTE! This method is called by internal thread, not Fluentd's main thread.
@@ -95,7 +96,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
   def write(chunk)
     messages = Array.new
 
-    chunk.msgpack_each do |tag, record|
+    chunk.msgpack_each do |tag, time, record|
       next unless record.is_a? Hash
       next if record.empty?
 
@@ -111,6 +112,10 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
 
       if @include_tag_key
         record[@tag_key] = tag
+      end
+      # If @timestamp_key already exists, we don't overwrite it.
+      if @timestamp_key and record[@timestamp_key].nil? and time:
+        record[@timestamp_key] = time.utc.iso8601(3)
       end
 
       container_tags = get_container_tags(record)


### PR DESCRIPTION
Fixes #23

### What does this PR do?

The timestamp of the log event is currently discarded (see #23). This PR fixes that and sends the timestamp of the log event to DataDog service.

Since Datadog can receive a JSON message, we pass it as `@timestamp` key, which is by default recognised by Datadog and then shown in the UI correctly.

### Motivation

Currently, timestamps of log events are not recorded correctly.

### Additional Notes

N/A