### PR TITLE
Add more logs attributes + update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,16 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 | **api_key** | This parameter is required in order to authenticate your fluent agent. | nil |
 | **use_json** | Event format, if true, the event is sent in json format. Othwerwise, in plain text. | true |
 | **include_tag_key** | Automatically include tags in the record. | false |
-| **tag_key** | Name of the tag attribute, if they are included. | "tag" |
+| **tag_key** | Name of the tag attribute, if they are included. | "fluentd_tag" |
 | **timestamp_key** | Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added. | "@timestamp" |
 | **use_ssl** | If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise. | true |
 | **ssl_port** | Port used to send logs over a SSL encripted connection to Datadog (use 443 for the EU region) | 10516 |
-| **max_retries** | The number of retries before the output plugin stops. Set to -1 for unlimited retries | -1 |
+| **max_retries** | The number of retries before the output plugin stops. Set to -1 for unlimited retries | 10 |
 | **dd_source** | This tells Datadog what integration it is | nil |
-| **dd_sourcecategory** | Multiple value attribute. Can be used to refine the source attribtue | nil |
+| **dd_sourcecategory** | Multiple value attribute. Can be used to refine the source attribute | nil |
 | **dd_tags** | Custom tags with the following format "key1:value1, key2:value2" | nil |
+| **dd_hostname** | Used by datadog to identify tge host submitting the logs. | `hostname -f` |
+| **service** | Used by Datadog to correlate between logs, traces and metrics. | nil |
 | **port** | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | 10514 |
 | **host** | Proxy endpoint when logs are not directly forwarded to Datadog | intake.logs.datadoghq.com |
 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 |-------------|--------------------------------------------------------------------------|----------------|
 | **api_key** | This parameter is required in order to authenticate your fluent agent. | nil |
 | **use_json** | Event format, if true, the event is sent in json format. Othwerwise, in plain text. | true |
-| **include_tag_key** | Automatically include tags in the record. | false |
-| **tag_key** | Name of the tag attribute, if they are included. | "fluentd_tag" |
+| **include_tag_key** | Automatically include the Fluentd tag in the record. | false |
+| **tag_key** | Where to store the Fluentd tag. | "tag" |
 | **timestamp_key** | Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added. | "@timestamp" |
 | **use_ssl** | If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise. | true |
 | **ssl_port** | Port used to send logs over a SSL encripted connection to Datadog (use 443 for the EU region) | 10516 |
-| **max_retries** | The number of retries before the output plugin stops. Set to -1 for unlimited retries | 10 |
+| **max_retries** | The number of retries before the output plugin stops. Set to -1 for unlimited retries | -1 |
 | **dd_source** | This tells Datadog what integration it is | nil |
 | **dd_sourcecategory** | Multiple value attribute. Can be used to refine the source attribute | nil |
 | **dd_tags** | Custom tags with the following format "key1:value1, key2:value2" | nil |
-| **dd_hostname** | Used by datadog to identify tge host submitting the logs. | `hostname -f` |
+| **dd_hostname** | Used by Datadog to identify the host submitting the logs. | `hostname -f` |
 | **service** | Used by Datadog to correlate between logs, traces and metrics. | nil |
 | **port** | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | 10514 |
 | **host** | Proxy endpoint when logs are not directly forwarded to Datadog | intake.logs.datadoghq.com |

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -12,21 +12,24 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
 
   # Register the plugin
   Fluent::Plugin.register_output('datadog', self)
+
   # Output settings
   config_param :use_json,           :bool,    :default => true
   config_param :include_tag_key,    :bool,    :default => false
-  config_param :tag_key,            :string,  :default => 'tag'
+  config_param :tag_key,            :string,  :default => 'fluentd_tag'
   config_param :timestamp_key,      :string,  :default => '@timestamp'
+  config_param :service,            :string,  :default => nil
   config_param :dd_sourcecategory,  :string,  :default => nil
   config_param :dd_source,          :string,  :default => nil
   config_param :dd_tags,            :string,  :default => nil
+  config_param :dd_hostname,        :string,  :default => nil
 
   # Connection settings
   config_param :host,           :string,  :default => 'intake.logs.datadoghq.com'
   config_param :use_ssl,        :bool,    :default => true
   config_param :port,           :integer, :default => 10514
   config_param :ssl_port,       :integer, :default => 10516
-  config_param :max_retries,    :integer, :default => -1
+  config_param :max_retries,    :integer, :default => 10
   config_param :tcp_ping_rate,  :integer, :default => 10
 
   # API Settings
@@ -43,6 +46,10 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
 
   def configure(conf)
     super
+    return if @dd_hostname
+    
+    @dd_hostname = %x[hostname -f 2> /dev/null].strip
+    @dd_hostname = Socket.gethostname if @dd_hostname.empty?
   end
 
   def multi_workers_ready?
@@ -111,6 +118,12 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
       end
       if @dd_tags
         record["ddtags"] = @dd_tags
+      end
+      if @service
+        record["service"] = @service
+      end
+      if @dd_hostname
+        record["hostname"] = @dd_hostname
       end
 
       if @include_tag_key

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -16,7 +16,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
   # Output settings
   config_param :use_json,           :bool,    :default => true
   config_param :include_tag_key,    :bool,    :default => false
-  config_param :tag_key,            :string,  :default => 'fluentd_tag'
+  config_param :tag_key,            :string,  :default => 'tag'
   config_param :timestamp_key,      :string,  :default => '@timestamp'
   config_param :service,            :string,  :default => nil
   config_param :dd_sourcecategory,  :string,  :default => nil
@@ -29,7 +29,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
   config_param :use_ssl,        :bool,    :default => true
   config_param :port,           :integer, :default => 10514
   config_param :ssl_port,       :integer, :default => 10516
-  config_param :max_retries,    :integer, :default => 10
+  config_param :max_retries,    :integer, :default => -1
   config_param :tcp_ping_rate,  :integer, :default => 10
 
   # API Settings
@@ -47,7 +47,7 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
   def configure(conf)
     super
     return if @dd_hostname
-    
+
     @dd_hostname = %x[hostname -f 2> /dev/null].strip
     @dd_hostname = Socket.gethostname if @dd_hostname.empty?
   end


### PR DESCRIPTION
This PR adds the `hostname` and `service` attributes to the configuration which are helpful within datadog to correlate between logs, metrics and traces coming from different hosts.

If the hostname is not configured, the default behavior is to use the fqdn using `hostname -f`, or using `Socket.gethostname`


I also took the opportunity to update the Readme and describe all the possible configuration options.
I also added a default limit to the number of retries in case of failures.