### PR TITLE
Don't override hostname and other properties if they are already set in the incoming record

### DIFF
--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -9,7 +9,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-datadog"
-  spec.version       = "0.11.0"
+  spec.version       = "0.11.1"
   spec.authors       = ["Datadog Solutions Team"]
   spec.email         = ["support@datadoghq.com"]
   spec.summary       = "Datadog output plugin for Fluent event collector"

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -111,19 +111,19 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
       next if record.empty?
 
       if @dd_sourcecategory
-        record["ddsourcecategory"] = @dd_sourcecategory
+        record["ddsourcecategory"] ||= @dd_sourcecategory
       end
       if @dd_source
-        record["ddsource"] = @dd_source
+        record["ddsource"] ||= @dd_source
       end
       if @dd_tags
-        record["ddtags"] = @dd_tags
+        record["ddtags"] ||= @dd_tags
       end
       if @service
-        record["service"] = @service
+        record["service"] ||= @service
       end
       if @dd_hostname
-        record["hostname"] = @dd_hostname
+        record["hostname"] ||= @dd_hostname
       end
 
       if @include_tag_key


### PR DESCRIPTION
### What does this PR do?

This pull request fixes a regression introduced in https://github.com/DataDog/fluent-plugin-datadog/pull/28 that causes `hostname` and other attributes to be overridden. The behaviour introduced in that previous PR breaks expected behaviour in certain situations, such as in a fluentd aggregator configuration where log entries originate from different fluentd instances and are funnelled to datadog through an aggregator.

The proposed change aims to restore the original behaviour while retaining the ability to set a hostname and other attributes through `@dd_hostname`, `@service`, etc.

### Motivation

PR#28 broke our fluentd aggregator configuration, making it impossible to determine the actual originating hostname of a log entry funnelled to datadog.

### Additional Notes

We tested this in our aggregator setup and it worked fine 👍 