### PR TITLE
Add a comment on why we set the record hostname if none is present in the record.

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -123,6 +123,9 @@ class Fluent::DatadogOutput < Fluent::BufferedOutput
         record["service"] ||= @service
       end
       if @dd_hostname
+        # set the record hostname to the configured dd_hostname only
+        # if the record hostname is empty, ensuring having a hostname set
+        # even if the record doesn't contain any.
         record["hostname"] ||= @dd_hostname
       end
 


### PR DESCRIPTION
Add a comment on why we set the record hostname if none is present in the record.
