### PR TITLE
make the api_key param secret

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -54,7 +54,7 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
   config_param :use_json, :bool, :default => true
 
   # API Settings
-  config_param :api_key, :string
+  config_param :api_key, :string, secret: true
 
   config_section :buffer do
     config_set_default :@type, DEFAULT_BUFFER_TYPE


### PR DESCRIPTION
### What does this PR do?

Make the `api_key` parameter as secret so it will not be printed when fluentd startup

### Motivation

We don't want to expose the `api_key` in fluentd log as a plain text. Use `secret = true` is a standard behavior for fluentd plugins for protecting sensitive info.

### Additional Notes

Anything else we should know when reviewing?