### PR TITLE
[Fluent]: v0.12.1, catch lingering exceptions, upgrade persistent http to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.1
+ - Address persistent connection creation issues 
+
 ## 0.12.0
  - Migrate to Fluentd v1 APIs
  - Enable HTTP forwarding by default

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 | **dd_hostname** | Used by Datadog to identify the host submitting the logs. | `hostname -f` |
 | **service** | Used by Datadog to correlate between logs, traces and metrics. | nil |
 | **port** | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | 80 |
-| **host** | Proxy endpoint when logs are not directly forwarded to Datadog | intake.logs.datadoghq.com |
+| **host** | Proxy endpoint when logs are not directly forwarded to Datadog | http-intake.logs.datadoghq.com |
 
 ### Docker and Kubernetes tags
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ TCP example:
 
   # Optional parameters
   dd_source '<INTEGRATION_NAME>' 
-  dd_tags '<KEY1:VALU1>,<KEY2:VALUE2>'
+  dd_tags '<KEY1:VALUE1>,<KEY2:VALUE2>'
   dd_sourcecategory '<MY_SOURCE_CATEGORY>'
   <buffer>
           @type memory

--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -9,25 +9,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-datadog"
-  spec.version       = "0.12.0"
+  spec.version       = "0.12.1"
   spec.authors       = ["Datadog Solutions Team"]
   spec.email         = ["support@datadoghq.com"]
   spec.summary       = "Datadog output plugin for Fluent event collector"
   spec.homepage      = "http://datadoghq.com"
-  spec.license       = "Apache License 2.0"
+  spec.license       = "Apache-2.0"
 
   spec.files         = [".gitignore", "Gemfile", "LICENSE", "README.md", "Rakefile", "fluent-plugin-datadog.gemspec", "lib/fluent/plugin/out_datadog.rb"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_runtime_dependency "fluentd", [">= 1", "< 2"]
-  spec.add_runtime_dependency "net-http-persistent", '~> 2.9'
+  spec.add_runtime_dependency "net-http-persistent", '~> 3.1'
 
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "test-unit", '~> 3.1'
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "yajl-ruby", "~> 1.2"
-
-
+  spec.add_development_dependency 'webmock', "~> 3.5.0"
 end


### PR DESCRIPTION
### What does this PR do?

- Ensure that any uncaught exception is logged
- Fix persistent connection init from name
- Upgrade persistent HTTP to 3.1.0

