### PR TITLE
change min required fluentd version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ if you don't wan't to.
 
 | fluent-plugin-datadog | Fluentd    | Ruby   |
 |:--------------------------|:-----------|:-------|
-| \>= 0.12.0               | \>= v1      | \>= 2.4 |
+| \>= 0.12.0               | \>= v1.7.0      | \>= 2.4 |
 | < 0.12.0                   | \>= v0.12.0 | \>= 2.1 |
 
 To add the plugin to your fluentd agent, use the following command:


### PR DESCRIPTION
Using v0.12.1 with fluentd v1.3.1 didn't work. Upgrading to 1.9.1 seemed to fix the issue.

Perhaps this has to do with changes to `out_http` since 1.7.0: https://docs.fluentd.org/output/http

### What does this PR do?

Updates documentation

### Motivation

Plugin was not working with `fluent/fluentd:latest` image
