### PR TITLE
Add support for HTTP proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ HTTP example:
   dd_sourcecategory '<MY_SOURCE_CATEGORY>'
 
   # Optional http proxy
-  proxy 'http://my-proxy.example'
+  http_proxy 'http://my-proxy.example'
 
   <buffer>
           @type memory
@@ -102,7 +102,7 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 | **service** | Used by Datadog to correlate between logs, traces and metrics. | nil |
 | **port** | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | 80 |
 | **host** | Proxy endpoint when logs are not directly forwarded to Datadog | http-intake.logs.datadoghq.com |
-| **proxy** | HTTP proxy, only takes effect if HTTP forwarding is enabled (`use_http`). Defaults to `HTTP_PROXY`/`http_proxy` env vars. | nil |
+| **http_proxy** | HTTP proxy, only takes effect if HTTP forwarding is enabled (`use_http`). Defaults to `HTTP_PROXY`/`http_proxy` env vars. | nil |
 
 ### Docker and Kubernetes tags
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you installed the td-agent instead
 
 To match events and send them to Datadog, simply add the following code to your configuration file.
 
-TCP example:
+HTTP example:
 
 ```xml
 # Match events tagged with "datadog.**" and
@@ -40,9 +40,13 @@ TCP example:
   tag_key 'tag'
 
   # Optional parameters
-  dd_source '<INTEGRATION_NAME>' 
+  dd_source '<INTEGRATION_NAME>'
   dd_tags '<KEY1:VALUE1>,<KEY2:VALUE2>'
   dd_sourcecategory '<MY_SOURCE_CATEGORY>'
+
+  # Optional http proxy
+  proxy 'http://my-proxy.example'
+
   <buffer>
           @type memory
           flush_thread_count 4
@@ -50,7 +54,6 @@ TCP example:
           chunk_limit_size 5m
           chunk_limit_records 500
   </buffer>
-
 
 </match>
 ```
@@ -99,6 +102,7 @@ As fluent-plugin-datadog is an output_buffer, you can set all output_buffer prop
 | **service** | Used by Datadog to correlate between logs, traces and metrics. | nil |
 | **port** | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | 80 |
 | **host** | Proxy endpoint when logs are not directly forwarded to Datadog | http-intake.logs.datadoghq.com |
+| **proxy** | HTTP proxy, only takes effect if HTTP forwarding is enabled (`use_http`). Defaults to `HTTP_PROXY`/`http_proxy` env vars. | nil |
 
 ### Docker and Kubernetes tags
 

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -49,6 +49,7 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
   config_param :use_compression, :bool, :default => true
   config_param :compression_level, :integer, :default => 6
   config_param :no_ssl_validation, :bool, :default => false
+  config_param :proxy, :string, :default => nil
 
   # Format settings
   config_param :use_json, :bool, :default => true
@@ -88,7 +89,7 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
 
   def start
     super
-    @client = new_client(log, @api_key, @use_http, @use_ssl, @no_ssl_validation, @host, @ssl_port, @port, @use_compression)
+    @client = new_client(log, @api_key, @use_http, @use_ssl, @no_ssl_validation, @host, @ssl_port, @port, @proxy, @use_compression)
   end
 
   def shutdown
@@ -260,9 +261,9 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
   end
 
   # Build a new transport client
-  def new_client(logger, api_key, use_http, use_ssl, no_ssl_validation, host, ssl_port, port, use_compression)
+  def new_client(logger, api_key, use_http, use_ssl, no_ssl_validation, host, ssl_port, port, proxy, use_compression)
     if use_http
-      DatadogHTTPClient.new logger, use_ssl, no_ssl_validation, host, ssl_port, port, use_compression, api_key
+      DatadogHTTPClient.new logger, use_ssl, no_ssl_validation, host, ssl_port, port, proxy, use_compression, api_key
     else
       DatadogTCPClient.new logger, use_ssl, no_ssl_validation, host, ssl_port, port
     end
@@ -300,17 +301,27 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
     require 'net/http'
     require 'net/http/persistent'
 
-    def initialize(logger, use_ssl, no_ssl_validation, host, ssl_port, port, use_compression, api_key)
+    def initialize(logger, use_ssl, no_ssl_validation, host, ssl_port, port, proxy, use_compression, api_key)
       @logger = logger
       protocol = use_ssl ? "https" : "http"
       port = use_ssl ? ssl_port : port
       @uri = URI("#{protocol}://#{host}:#{port.to_s}/v1/input/#{api_key}")
+      proxy_uri = :ENV
+      if proxy
+        proxy_uri = URI.parse(proxy)
+      elsif ENV['HTTP_PROXY'] || ENV['http_proxy']
+        logger.info("Using HTTP proxy defined in `HTTP_PROXY`/`http_proxy` env vars")
+      end
       logger.info("Starting HTTP connection to #{protocol}://#{host}:#{port.to_s} with compression " + (use_compression ? "enabled" : "disabled"))
-      @client = Net::HTTP::Persistent.new name: "fluent-plugin-datadog-logcollector"
+      @client = Net::HTTP::Persistent.new name: "fluent-plugin-datadog-logcollector", proxy: proxy_uri
       @client.verify_mode = OpenSSL::SSL::VERIFY_NONE if no_ssl_validation
       @client.override_headers["Content-Type"] = "application/json"
       if use_compression
         @client.override_headers["Content-Encoding"] = "gzip"
+      end
+      if !@client.proxy_uri.nil?
+        # Log the proxy settings as resolved by the HTTP client
+        logger.info("Using HTTP proxy #{@client.proxy_uri.scheme}://#{@client.proxy_uri.host}:#{@client.proxy_uri.port} username: #{@client.proxy_uri.user ? "set" : "unset"}, password: #{@client.proxy_uri.password ? "set" : "unset"}")
       end
     end
 

--- a/test/plugin/test_out_datadog.rb
+++ b/test/plugin/test_out_datadog.rb
@@ -69,6 +69,18 @@ class FluentDatadogTest < Test::Unit::TestCase
       end
       ENV["HTTP_PROXY"] = nil
     end
+
+    test "invalid proxy raises exception" do
+      plugin = create_driver(%[
+        api_key foo
+        proxy tcp://invalid
+      ])
+      assert_not_nil plugin
+      assert_raise(ArgumentError) do
+        plugin.run do
+        end
+      end
+    end
   end
 
   sub_test_case "enrich_record" do

--- a/test/plugin/test_out_datadog.rb
+++ b/test/plugin/test_out_datadog.rb
@@ -41,7 +41,7 @@ class FluentDatadogTest < Test::Unit::TestCase
       ENV["HTTP_PROXY"] = "http://env-proxy-host:123"
       plugin = create_driver(%[
         api_key foo
-        proxy http://proxy-username:proxy-password@proxy-host.example:12345
+        http_proxy http://proxy-username:proxy-password@proxy-host.example:12345
       ])
       assert_not_nil plugin
       plugin.run do
@@ -73,7 +73,7 @@ class FluentDatadogTest < Test::Unit::TestCase
     test "invalid proxy raises exception" do
       plugin = create_driver(%[
         api_key foo
-        proxy tcp://invalid
+        http_proxy tcp://invalid
       ])
       assert_not_nil plugin
       assert_raise(ArgumentError) do

--- a/test/plugin/test_out_datadog.rb
+++ b/test/plugin/test_out_datadog.rb
@@ -32,9 +32,42 @@ class FluentDatadogTest < Test::Unit::TestCase
 
     test "api key should succeed" do
       plugin = create_driver(%[
-        api_key = foo
+        api_key foo
       ])
       assert_not_nil plugin
+    end
+
+    test "proxy is set correctly" do
+      ENV["HTTP_PROXY"] = "http://env-proxy-host:123"
+      plugin = create_driver(%[
+        api_key foo
+        proxy http://proxy-username:proxy-password@proxy-host.example:12345
+      ])
+      assert_not_nil plugin
+      plugin.run do
+        proxy_uri = plugin.instance.instance_variable_get(:@client).instance_variable_get(:@client).proxy_uri
+        assert_equal "proxy-host.example", proxy_uri.host
+        assert_equal 12345, proxy_uri.port
+        assert_equal "proxy-username", proxy_uri.user
+        assert_equal "proxy-password", proxy_uri.password
+      end
+      ENV["HTTP_PROXY"] = nil
+    end
+
+    test "proxy is pulled from env when not set in config" do
+      ENV["HTTP_PROXY"] = "http://env-proxy-host:123"
+      plugin = create_driver(%[
+        api_key foo
+      ])
+      assert_not_nil plugin
+      plugin.run do
+        proxy_uri = plugin.instance.instance_variable_get(:@client).instance_variable_get(:@client).proxy_uri
+        assert_equal "env-proxy-host", proxy_uri.host
+        assert_equal 123, proxy_uri.port
+        assert_equal nil, proxy_uri.user
+        assert_equal nil, proxy_uri.password
+      end
+      ENV["HTTP_PROXY"] = nil
     end
   end
 
@@ -170,7 +203,7 @@ class FluentDatadogTest < Test::Unit::TestCase
       api_key = 'XXX'
       stub_dd_request_with_return_code(api_key, 500)
       payload = '{}'
-      client = Fluent::DatadogOutput::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 443, 80, false, api_key
+      client = Fluent::DatadogOutput::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 443, 80, nil, false, api_key
       assert_raise(Fluent::DatadogOutput::RetryableError) do
         client.send(payload)
       end
@@ -180,7 +213,7 @@ class FluentDatadogTest < Test::Unit::TestCase
       api_key = 'XXX'
       stub_dd_request_with_return_code(api_key, 400)
       payload = '{}'
-      client = Fluent::DatadogOutput::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 443, 80, false, api_key
+      client = Fluent::DatadogOutput::DatadogHTTPClient.new Logger.new(STDOUT), false, false, "datadog.com", 443, 80, nil, false, api_key
       assert_nothing_raised do
         client.send(payload)
       end

--- a/test/plugin/test_out_datadog.rb
+++ b/test/plugin/test_out_datadog.rb
@@ -17,7 +17,7 @@ class FluentDatadogTest < Test::Unit::TestCase
 
   def create_valid_subject
     create_driver(%[
-        api_key = foo
+        api_key foo
       ]).instance
   end
 


### PR DESCRIPTION
### What does this PR do?

Adds support for HTTP proxy configuration, with consistent behavior with the `proxy` setting of the HTTP output plugin
(https://docs.fluentd.org/output/http#proxy) such as defaulting to standard `HTTP_PROXY` env vars, except that the option is called `http_proxy` for our plugin.

### Motivation

Customer request

### Additional Notes

Related docs: proxy config on the persistent http client we use: https://www.rubydoc.info/gems/net-http-persistent/3.1.0/Net/HTTP/Persistent#initialize-instance_method

Testing:

* I've run the tests locally, they pass.
* this change was confirmed to work on a lab setup by a Solutions Engineer