### PR TITLE
fix: dont call method on unitialized logger

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -141,7 +141,7 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
         end
       end
     rescue Exception => e
-      @logger.error("Uncaught processing exception in datadog forwarder #{e.message}")
+      log.error("Uncaught processing exception in datadog forwarder #{e.message}")
     end
   end
 


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the `error` method is called on a nil `@logger` instance variable. See https://github.com/DataDog/fluent-plugin-datadog/blob/49f8e4ecd68a93103779f5ec8fd889b0261d6b5d/lib/fluent/plugin/out_datadog.rb#L144

The `@logger` instance variable is only set in the `DatadogClient` class and its subclasses, but it is never initialized in the parent `Fluent::DatadogOutput` class. Instead, _I believe_ the output plugin should be using the `log` method of the [PluginLoggerMixin](https://github.com/fluent/fluentd/blob/master/lib/fluent/log.rb#L654). At least this would match the [example from the docs](https://docs.fluentd.org/plugin-development/api-plugin-output).

Note that I tried to write tests for this, but (a) was unable to mock a failed method call in test-unit and (b) was unable to access the instance of the Fluent log object to assert anything. Let me know if I'm missing something, happy to take another swing at a unit test if this is doable.

### Motivation

Any exception coming from the `write` method is lost. Right now it is very difficult to debug failures from the plugin. The only error message I'm getting is `undefined method 'error' for nil:NilClass`. This has come up in previous issues like https://github.com/DataDog/fluent-plugin-datadog/issues/41 as well

### Additional Notes

Anything else we should know when reviewing?

I appreciate your work on this Gem ❤️ 