### PR TITLE
chore: upgrade net-http-persistent library to new version

### DIFF
--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "fluentd", [">= 1", "< 2"]
-  spec.add_runtime_dependency "net-http-persistent", '~> 3.1'
+  spec.add_runtime_dependency "net-http-persistent", '~> 4.0.1'
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "test-unit", '~> 3.1'


### PR DESCRIPTION
Signed-off-by: Javier Criado Marcos <jcriadomarco@vmware.com>

### What does this PR do?
Update net-http-persistent to last version
### Motivation
We are struggling a lot while using these plugin along with splunk or elastic, because this plugin are using version 4.0.1 of net-http-persistent library. There is no breaking changes between the 2 version of net-http-persistent library

### Additional Notes
Here i will send you some examples of these problems in other repos: 
- https://github.com/banzaicloud/logging-operator/issues/907