### PR TITLE
add links to GitHub in gem metadata

### DIFF
--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -31,4 +31,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "yajl-ruby", "~> 1.2"
   spec.add_development_dependency 'webmock', "~> 3.6.0"
+
+  spec.metadata      = {
+    'bug_tracker_uri'   => 'https://github.com/DataDog/fluent-plugin-datadog/issues',
+    'changelog_uri'     => 'https://github.com/DataDog/fluent-plugin-datadog/blob/master/CHANGELOG.md',
+    'documentation_uri' => 'https://github.com/DataDog/fluent-plugin-datadog/blob/master/README.md',
+    'source_code_uri'   => 'https://github.com/DataDog/fluent-plugin-datadog'
+  }
 end


### PR DESCRIPTION
### What does this PR do?

Adds links to GitHub in gem metadata.

### Motivation

Make it easier to find the source code from RubyGems.

### Additional Notes

This is a small PR but I know nothing about Ruby so please make sure I didn't break anything.

Coded added has been copied from https://github.com/DataDog/dogapi-rb/blob/656e3260c01adac92f998f9f58993291efdc8a8b/dogapi.gemspec#L16 and adapted.