### PR TITLE
Allow setting `timestamp_key` to nil or null to supress timestamp

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -11,6 +11,10 @@ require "fluent/plugin/output"
 
 require_relative "version"
 
+def nilish?(s)
+  s.empty? || s == "nil" || s == "false" || s == "null"
+end
+
 class Fluent::DatadogOutput < Fluent::Plugin::Output
   class RetryableError < StandardError;
   end
@@ -80,6 +84,8 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
     # Set dd_hostname if not already set (can be set when using fluentd as aggregator)
     @dd_hostname = %x[hostname -f 2> /dev/null].strip
     @dd_hostname = Socket.gethostname if @dd_hostname.empty?
+
+    @timestamp_key = nil if nilish?(@timestamp_key)
   end
 
   def multi_workers_ready?

--- a/test/plugin/test_out_datadog.rb
+++ b/test/plugin/test_out_datadog.rb
@@ -120,6 +120,18 @@ class FluentDatadogTest < Test::Unit::TestCase
       assert_equal "1970-01-01T03:25:45.000Z", result["foo"]
     end
 
+    test "should not set timestamp tag if timestamp_key is nil" do
+      plugin = create_driver(%[
+        api_key foo
+        timestamp_key nil
+      ]).instance
+      time = 12345
+      record = {"message" => "bar"}
+      result = plugin.enrich_record(nil, time, record)
+      # only hostname and message fields are set, no timestamp field
+      assert_equal ["hostname", "message"], result.keys.sort
+    end
+
     test "should add specific datadog attributes" do
       plugin = create_driver(%[
         api_key foo


### PR DESCRIPTION
Fixes: https://github.com/DataDog/fluent-plugin-datadog/issues/59

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
