### PR TITLE
Sources container_id tag from kubernetes meta location

### DIFF
--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -426,6 +426,7 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
       tags.push("container_name:" + kubernetes['container_name']) unless kubernetes['container_name'].nil?
       tags.push("kube_namespace:" + kubernetes['namespace_name']) unless kubernetes['namespace_name'].nil?
       tags.push("pod_name:" + kubernetes['pod_name']) unless kubernetes['pod_name'].nil?
+      tags.push("container_id:" + kubernetes['docker_id']) unless kubernetes['docker_id'].nil?
       return tags.join(",")
     end
     nil


### PR DESCRIPTION
### What does this PR do?

Looks to resolve https://github.com/DataDog/fluent-plugin-datadog/issues/66

Sources the `container_id` tag from the default location the kubernetes input filter places the `container_id` attribute (`kubernetes.docker_id`).

### Motivation

What inspired you to submit this pull request?

This will allow drillthrough from the kubernetes dashboard views in datadog (at the container level) to be able to easily find logs as its filtering/searching based on `container_id`.  This is useful for pods that have multiple containers and you'd like it filtered for a specific container.

### Additional Notes

Anything else we should know when reviewing?