### PR TITLE
Adds option to delete extracted tag attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ As `fluent-plugin-datadog` is a buffered output plugin, you can set all of the b
 | **port** | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | 80 |
 | **host** | Proxy endpoint when logs are not directly forwarded to Datadog | http-intake.logs.datadoghq.com |
 | **http_proxy** | HTTP proxy, only takes effect if HTTP forwarding is enabled (`use_http`). Defaults to `HTTP_PROXY`/`http_proxy` env vars. | nil |
+| **delete_extracted_tag_attributes** | When true, removes `kubernetes` and `docker` attributes from log records after extracting them as tags. Useful to avoid duplicate data in Datadog logs UI. | false |
 
 ### Docker and Kubernetes tags
 
@@ -114,6 +115,8 @@ If your logs contain any of the following attributes, it will automatically be a
 * kubernetes.namespace_name
 * kubernetes.pod_name
 * docker.container_id
+
+**Note:** By default, these values will appear twice in the Datadog logs UI, once as tags (e.g., `container_name:myapp`) and once as attributes (e.g., `@kubernetes.container_name`). If you prefer to avoid this duplication, set `delete_extracted_tag_attributes` to `true` in your configuration. This will remove the `kubernetes` and `docker` attributes from the log record after the tags have been extracted.
 
 If the Datadog Agent collect them automatically, FluentD requires a plugin for this. We recommend using [fluent-plugin-kubernetes_metadata_filter](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter) to collect Docker and Kubernetes metadata.
 

--- a/lib/fluent/plugin/out_datadog.rb
+++ b/lib/fluent/plugin/out_datadog.rb
@@ -43,6 +43,7 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
   config_param :dd_source, :string, :default => nil
   config_param :dd_tags, :string, :default => nil
   config_param :dd_hostname, :string, :default => nil
+  config_param :delete_extracted_tag_attributes, :bool, :default => false
 
   # Connection settings
   config_param :host, :string, :default => DD_DEFAULT_HTTP_ENDPOINT
@@ -254,6 +255,12 @@ class Fluent::DatadogOutput < Fluent::Plugin::Output
         record["ddtags"] = record["ddtags"] + "," + container_tags
       end
     end
+
+    if @delete_extracted_tag_attributes
+      record.delete('kubernetes')
+      record.delete('docker')
+    end
+
     record
   end
 


### PR DESCRIPTION
### What does this PR do?

Currently this plugin duplicates docker and kubernetes attributes into tags.  While useful, this means that the logs uploaded to datadog are now larger than they otherwise would be, leading to increased bytes ingested and therefore increased costs.  This PR aims to provide a configuration option to delete kubernetes and docker attributes from the log after the relevant information has been extracted into tags.

This should address the issue https://github.com/DataDog/fluent-plugin-datadog/issues/42 that has been open for 5 years at this point.

### Motivation

Removing this duplicative data should reduce load and costs for people using the plugin.  In a test from logs on my applications I was seeing a roughly 30% reduction in overall bytes ingested.

### Additional Notes

This change intentionally removes _all_ docker and kubernetes attributes from the logs after the relevant tags are extracted, not limited to just the ones that are specifically added as tags as part of the plugin.  Many of the attributes are already included elsewhere as tags, and IMO the improvement from cleaning them all up is worth the trade off of potentially needing to map a couple custom kubernetes / docker attributes to a different spot in the record if someone does not want them removed.