### PR TITLE
Thvc 15515 upgrade ruby version for fluent plugin datadog to 4 x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 A brief description of the change being made with this pull request.
 
+Jira ticket: THVC-
+
 ### Motivation
 
 What inspired you to submit this pull request?

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,7 @@
 
 source 'https://rubygems.org'
 
+ruby ">= 4.0"
+
 # Specify your gem's dependencies in fluent-plugin-datadog.gemspec
 gemspec

--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -9,7 +9,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-datadog"
-  spec.version       = "0.11.1"
+  spec.version       = "0.11.2"
   spec.authors       = ["Datadog Solutions Team"]
   spec.email         = ["support@datadoghq.com"]
   spec.summary       = "Datadog output plugin for Fluent event collector"
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "yajl-ruby", "~> 1.2"
 end

--- a/fluent-plugin-datadog.gemspec
+++ b/fluent-plugin-datadog.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 4.0"
 
   spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

Upgrades the minimum Ruby version requirement to 4.0 in the gemspec and Gemfile.
