### PR TITLE
Add Trusted Publishing workflow for RubyGems releases

### DIFF
--- a/.github/chainguard/self.publish.sts.yaml
+++ b/.github/chainguard/self.publish.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/fluent-plugin-datadog:environment:rubygems.org
+
+claim_pattern:
+  event_name: workflow_dispatch
+  environment: rubygems.org
+  ref: refs/heads/master
+  repository: DataDog/fluent-plugin-datadog
+  job_workflow_ref: DataDog/fluent-plugin-datadog/\.github/workflows/publish\.yml@refs/heads/master
+
+permissions:
+  contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish gem
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push gem to RubyGems.org (false = dry run, true = publish)"
+        type: boolean
+        default: false
+        required: false
+
+concurrency: "rubygems"
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Build and publish gem to RubyGems.org
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.push && 'rubygems.org' || '' }}
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Verify gem version is not already published
+        run: |
+          GEM_VERSION=$(ruby -e "puts Gem::Specification.load('fluent-plugin-datadog.gemspec').version")
+          echo "GEM_VERSION=${GEM_VERSION}" >> "$GITHUB_ENV"
+
+          if gem search fluent-plugin-datadog --exact --remote --version "${GEM_VERSION}" | grep -q "(${GEM_VERSION})"; then
+            echo "::error::Version ${GEM_VERSION} is already published on RubyGems.org"
+            exit 1
+          fi
+          echo "Version ${GEM_VERSION} is ready to publish"
+
+      - name: Build gem (dry run)
+        if: ${{ !inputs.push }}
+        run: |
+          gem build fluent-plugin-datadog.gemspec
+          echo "::notice::Dry run complete. Gem built successfully: fluent-plugin-datadog-${GEM_VERSION}.gem"
+
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        if: ${{ inputs.push }}
+        id: octo-sts
+        with:
+          scope: DataDog/fluent-plugin-datadog
+          policy: self.publish
+      - name: Publish to RubyGems.org
+        if: ${{ inputs.push }}
+        uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Switch to GitHub Actions Trusted Publishing for gem releases (replaces manual API key publishing) [#89](https://github.com/DataDog/fluent-plugin-datadog/pull/89)
+
 ## 0.15.0
 - Provide a configuration option to delete kubernetes and docker attributes from the log after the relevant information has been extracted into tags [#78](https://github.com/DataDog/fluent-plugin-datadog/pull/78) by [@sambart19].
 - Fix launch.json and update readme [#76](https://github.com/DataDog/fluent-plugin-datadog/pull/76)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Configuration example:
 </filter>
 ```
 
+## Build
+
+To build the gem locally:
+
+- `rake build` to build the gem file
+
 ## Releasing
 
 This gem is published to RubyGems via a GitHub Actions [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) workflow. No API keys or local credentials are needed.

--- a/README.md
+++ b/README.md
@@ -148,17 +148,19 @@ Configuration example:
 </filter>
 ```
 
-## Build
+## Releasing
 
-To build a new version of this plugin and push it to RubyGems:
+This gem is published to RubyGems via a GitHub Actions [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) workflow. No API keys or local credentials are needed.
 
-- Update the version in the .gemspec file accordingly
-- `rake build` to build the gem file
-- `rake release` to push the new gem to RubyGems
+To release a new version:
 
-**Note**: The latest command will fail without appropriate credentials configured. You can set those credentials by running the following command:
-
-`curl -u <USERNAME> https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials`, it will ask for your password.
+1. Update the version in `lib/fluent/plugin/version.rb`
+2. Update `CHANGELOG.md`
+3. Merge to `master`
+4. Go to **Actions** > **Publish gem** > **Run workflow**
+5. Run with `push` unchecked first (dry run) to verify the build
+6. Run again with `push` checked to publish to RubyGems
+7. The `rubygems.org` environment gate will ask for approval before publishing
 
 ## Development Environment
 


### PR DESCRIPTION
### What does this PR do?

Replace the static rubygems.org API key with a GitHub Actions OIDC-based Trusted Publishing workflow.

### Motivation
SDLC Security review

### Additional Notes
Part of the SDLC Security audit: https://datadoghq.atlassian.net/wiki/spaces/~776423855/pages/6936626815/Ruby+Package+Publishing
